### PR TITLE
11  - add comment count to GET /api/articles/:articleid

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -178,16 +178,26 @@ describe("GET /api/articles/:article_id", () => {
       .expect(200)
       .then(({ body }) => {
         const { article } = body;
-        expect(article).toEqual({
-          article_id: 1,
-          author: "butter_bridge",
-          title: "Living in the shadow of a great man",
-          body: "I find this existence challenging",
-          topic: "mitch",
-          created_at: "2020-07-09T20:11:00.000Z",
-          votes: 100,
-          comment_count: 11,
-        });
+        expect(article).toEqual(
+          expect.objectContaining({
+            article_id: 1,
+            author: "butter_bridge",
+            title: "Living in the shadow of a great man",
+            body: "I find this existence challenging",
+            topic: "mitch",
+            created_at: "2020-07-09T20:11:00.000Z",
+            votes: 100,
+          })
+        );
+      });
+  });
+  test("200: returns an article with comment_count to the client", () => {
+    return request(app)
+      .get("/api/articles/1")
+      .expect(200)
+      .then(({ body }) => {
+        const { article } = body;
+        expect(article.comment_count).toBe(11);
       });
   });
   test("400: returns an error message when passed an invalid id", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -92,6 +92,7 @@ describe("GET /api/articles/:article_id", () => {
           topic: "mitch",
           created_at: "2020-07-09T20:11:00.000Z",
           votes: 100,
+          comment_count: 11,
         });
       });
   });

--- a/models/articles.js
+++ b/models/articles.js
@@ -19,7 +19,7 @@ exports.selectArticles = (query) => {
   const queryValues = [];
   let queryStr = `
     SELECT articles.article_id, title, topic, articles.author, articles.created_at, articles.votes, 
-    COUNT(comment_id) as comment_count 
+    COUNT(comment_id)::INT as comment_count 
     FROM articles
     LEFT JOIN comments on comments.article_id = articles.article_id
   `;

--- a/models/articles.js
+++ b/models/articles.js
@@ -6,7 +6,7 @@ exports.selectArticles = () => {
     .query(
       `
   SELECT articles.article_id, title, topic, articles.author, articles.created_at, articles.votes, 
-  COUNT(comment_id) as comment_count 
+  COUNT(comment_id)::INT as comment_count 
   FROM articles
   LEFT JOIN comments on comments.article_id = articles.article_id
   GROUP BY articles.article_id
@@ -23,12 +23,15 @@ exports.selectArticleById = (id) => {
       `SELECT articles.article_id,
       articles.author,
       title,
-      body,
+      articles.body,
       topic,
-      created_at,
-      votes
+      articles.created_at,
+      articles.votes,
+      COUNT(comment_id)::INT as comment_count 
       FROM articles
-      WHERE article_id = $1`,
+      LEFT JOIN comments on comments.article_id = articles.article_id
+      WHERE articles.article_id = $1
+      GROUP BY articles.article_id`,
       [id]
     )
     .then(({ rows }) => {


### PR DESCRIPTION
https://trello.com/c/YQa7OcM0/4-11-get-api-articles-articleid-comment-count

I updated another endpoint to return an int comment count so that they were consistent as part of this PR.