### PR TITLE
14 - add pg-format as a prod dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,14 @@
       "dependencies": {
         "dotenv": "^16.0.0",
         "express": "^4.18.2",
-        "pg": "^8.7.3"
+        "pg": "^8.7.3",
+        "pg-format": "^1.0.4"
       },
       "devDependencies": {
         "husky": "^7.0.0",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
         "jest-sorted": "^1.0.14",
-        "pg-format": "^1.0.4",
         "supertest": "^6.3.1"
       }
     },
@@ -3794,8 +3794,7 @@
     "node_modules/pg-format": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
-      "integrity": "sha1-J3NCNsKtP05QZJFaWTNOIAQKgo4=",
-      "dev": true,
+      "integrity": "sha512-YyKEF78pEA6wwTAqOUaHIN/rWpfzzIuMh9KdAhc3rSLQ/7zkRFcCgYBAEGatDstLyZw4g0s9SNICmaTGnBVeyw==",
       "engines": {
         "node": ">=4.0"
       }
@@ -7815,8 +7814,7 @@
     "pg-format": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
-      "integrity": "sha1-J3NCNsKtP05QZJFaWTNOIAQKgo4=",
-      "dev": true
+      "integrity": "sha512-YyKEF78pEA6wwTAqOUaHIN/rWpfzzIuMh9KdAhc3rSLQ/7zkRFcCgYBAEGatDstLyZw4g0s9SNICmaTGnBVeyw=="
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
     "jest-sorted": "^1.0.14",
-    "pg-format": "^1.0.4",
     "supertest": "^6.3.1"
   },
   "dependencies": {
     "dotenv": "^16.0.0",
     "express": "^4.18.2",
-    "pg": "^8.7.3"
+    "pg": "^8.7.3",
+    "pg-format": "^1.0.4"
   },
   "jest": {
     "setupFilesAfterEnv": [


### PR DESCRIPTION
Needed to merge last one to test 
link is https://frantic-erin-ant.cyclic.app/ but currently throwing an error 
Error: Cannot find module 'pg-format'
this is because I accidentally installed pg-format as a dev dependency.
I've now fixed this!